### PR TITLE
SPM로 배포하는 라이브러리에 헤더 파일이 누락되는 현상을 제거합니다.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
   targets: [
     .target(
       name: "TouchAreaInsets",
-      path: "Sources"
+      path: "Sources",
+      publicHeadersPath: "."
     )
   ],
   swiftLanguageVersions: [.v5]


### PR DESCRIPTION
## 배경

- 패키지 설정에 뭔가가 누락되어 workspace 에서 이 의존성을 SPM 으로 가져올 때 헤더 파일이 누락되는 것을 발견했습니다.

## 작업 내용

- 패키지 설정에 `publicHeadersPath` 옵션을 루트 폴더로 설정해, `Sources/` 폴더에 있는 헤더 파일들이 포함되도록 합니다. 

## 리뷰 노트

- 원래 헤더 파일이 있는 경우 정석 설정은 `Sources/include/` 라고 합니다. 다만 이런 식으로 커스텀으로 지정하는 것도 문제는 없고 많이들 하는 것 같습니다. 